### PR TITLE
Fix React starter kit link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Free Learning Resources related to Web-Development 🔥❤
 
 * For More tutorials and resources you can youtube or google this are some i find you can contribute more .
 # Reactjs
-- [Glitch: React Starter Kit](https://glitch.com/glimmer/post/react-starter-kit/) - A free, 5-part video course with interactive code examples that will help you learn React.
+- [Glitch: React Starter Kit](https://glitch.com/glimmer/post/react-starter-kit) - A free, 5-part video course with interactive code examples that will help you learn React.
 
 - [Codecademy: React 101](https://www.codecademy.com/learn/react-101) - Codecademy's introductory course for React.
 


### PR DESCRIPTION
https://glitch.com/glimmer/post/react-starter-kit/ with the `/` at the end is broken. https://glitch.com/glimmer/post/react-starter-kit works.